### PR TITLE
Fix bugs found during code audit

### DIFF
--- a/src/main/java/org/chappiebot/rag/RetrievalProvider.java
+++ b/src/main/java/org/chappiebot/rag/RetrievalProvider.java
@@ -36,6 +36,20 @@ import java.util.stream.Collectors;
 @ApplicationScoped
 public class RetrievalProvider {
 
+    private static final Map<String, List<String>> SYNONYMS = Map.ofEntries(
+        Map.entry("startup", List.of("lifecycle", "init", "initialization")),
+        Map.entry("start", List.of("lifecycle", "init", "initialization")),
+        Map.entry("lifecycle", List.of("startup", "init")),
+        Map.entry("injection", List.of("cdi", "dependency")),
+        Map.entry("cdi", List.of("injection", "dependency")),
+        Map.entry("validation", List.of("hibernate-validator", "validator")),
+        Map.entry("validate", List.of("hibernate-validator", "validator")),
+        Map.entry("validator", List.of("validation", "validate")),
+        Map.entry("hibernate-validator", List.of("validation", "validate")),
+        Map.entry("mode", List.of("dev-mode", "continuous-testing")),
+        Map.entry("cors", List.of("cross-origin"))
+    );
+
     @Inject
     StoreManager storeManager;
 
@@ -244,23 +258,8 @@ public class RetrievalProvider {
                       "using", "quarkus", "guide").contains(word);
     }
 
-    /**
-     * Returns synonyms and related terms for common technical keywords.
-     * Helps match queries like "startup" with documents about "lifecycle".
-     */
     private List<String> getSynonyms(String word) {
-        return switch (word) {
-            case "startup", "start" -> List.of("lifecycle", "init", "initialization");
-            case "lifecycle" -> List.of("startup", "init");
-            // Note: Don't map "inject" to "cdi" as it causes false positives (config injection vs bean injection)
-            case "injection" -> List.of("cdi", "dependency");  // Only "injection", not "inject"
-            case "cdi" -> List.of("injection", "dependency");
-            case "validation", "validate" -> List.of("hibernate-validator", "validator");
-            case "validator", "hibernate-validator" -> List.of("validation", "validate");
-            case "mode" -> List.of("dev-mode", "continuous-testing");
-            case "cors" -> List.of("cross-origin");
-            default -> List.of();
-        };
+        return SYNONYMS.getOrDefault(word, List.of());
     }
 
     private static SearchMatch extractContent(EmbeddingMatch<TextSegment> embeddingMatch) {

--- a/src/main/java/org/chappiebot/search/SearchEndpoint.java
+++ b/src/main/java/org/chappiebot/search/SearchEndpoint.java
@@ -9,6 +9,8 @@ import org.chappiebot.rag.RetrievalProvider;
 import java.util.List;
 import java.util.Objects;
 
+import jakarta.ws.rs.core.Response;
+
 
 @Path("/api/search")
 public class SearchEndpoint {
@@ -17,14 +19,19 @@ public class SearchEndpoint {
     RetrievalProvider retrievalProvider;
 
     @POST
-    public SearchResponse search(SearchRequest query) {
+    public Response search(SearchRequest query) {
+        if (query == null || query.queryMessage() == null || query.queryMessage().isBlank()) {
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(new SearchResponse(List.of()))
+                    .build();
+        }
         Log.info("Search request: " + query.queryMessage());
         String queryMessage = query.queryMessage();
         int maxResults = Objects.requireNonNullElse(query.maxResults(), retrievalProvider.getRagMaxResults());
         String restrictToExtension = query.extension();
 
         List<SearchMatch> search = retrievalProvider.search(queryMessage, maxResults, restrictToExtension);
-        return new SearchResponse(search);
+        return Response.ok(new SearchResponse(search)).build();
     }
 
 }

--- a/src/main/java/org/chappiebot/store/JdbcChatMemoryStore.java
+++ b/src/main/java/org/chappiebot/store/JdbcChatMemoryStore.java
@@ -269,18 +269,24 @@ public class JdbcChatMemoryStore implements ChatMemoryStore {
 
         try (Connection c = ds.getConnection()) {
             c.setAutoCommit(false);
+            try {
+                try (PreparedStatement pm = c.prepareStatement(delMsgs)) {
+                    pm.setString(1, memoryId);
+                    pm.executeUpdate();
+                }
 
-            try (PreparedStatement pm = c.prepareStatement(delMsgs)) {
-                pm.setString(1, memoryId);
-                pm.executeUpdate();
+                try (PreparedStatement pn = c.prepareStatement(delName)) {
+                    pn.setString(1, memoryId);
+                    pn.executeUpdate();
+                }
+
+                c.commit();
+            } catch (SQLException e) {
+                c.rollback();
+                throw e;
+            } finally {
+                c.setAutoCommit(true);
             }
-
-            try (PreparedStatement pn = c.prepareStatement(delName)) {
-                pn.setString(1, memoryId);
-                pn.executeUpdate();
-            }
-
-            c.commit();
         } catch (SQLException e) {
             throw new RuntimeException("Failed to delete conversation for " + memoryId, e);
         }
@@ -291,23 +297,30 @@ public class JdbcChatMemoryStore implements ChatMemoryStore {
         // We rewrite the full set; simpler and correct for windowed memory.
         String deleteSql = "DELETE FROM " + table + " WHERE memory_id = ?";
         String insertSql = "INSERT INTO " + table + " (memory_id, msg_index, message_json, last_modified) VALUES (?, ?, ?::jsonb, now())";
-        
+
         try (Connection c = ds.getConnection()) {
             c.setAutoCommit(false);
-            try (PreparedStatement del = c.prepareStatement(deleteSql)) {
-                del.setString(1, String.valueOf(memoryId));
-                del.executeUpdate();
-            }
-            try (PreparedStatement ins = c.prepareStatement(insertSql)) {
-                for (int i = 0; i < messages.size(); i++) {
-                    ins.setString(1, String.valueOf(memoryId));
-                    ins.setInt(2, i);
-                    ins.setString(3, ChatMessageSerializer.messageToJson(messages.get(i)));
-                    ins.addBatch();
+            try {
+                try (PreparedStatement del = c.prepareStatement(deleteSql)) {
+                    del.setString(1, String.valueOf(memoryId));
+                    del.executeUpdate();
                 }
-                ins.executeBatch();
+                try (PreparedStatement ins = c.prepareStatement(insertSql)) {
+                    for (int i = 0; i < messages.size(); i++) {
+                        ins.setString(1, String.valueOf(memoryId));
+                        ins.setInt(2, i);
+                        ins.setString(3, ChatMessageSerializer.messageToJson(messages.get(i)));
+                        ins.addBatch();
+                    }
+                    ins.executeBatch();
+                }
+                c.commit();
+            } catch (SQLException e) {
+                c.rollback();
+                throw e;
+            } finally {
+                c.setAutoCommit(true);
             }
-            c.commit();
         } catch (SQLException e) {
             throw new RuntimeException("Failed to update chat memory for " + memoryId, e);
         }

--- a/src/main/java/org/chappiebot/store/StoreEndpoint.java
+++ b/src/main/java/org/chappiebot/store/StoreEndpoint.java
@@ -16,6 +16,7 @@ import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.QueryParam;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
+import io.quarkus.logging.Log;
 import java.util.List;
 import java.util.Map;
 
@@ -96,11 +97,13 @@ public class StoreEndpoint {
     @Path("/chats")
     @Produces(MediaType.APPLICATION_JSON)
     public Response getChats(@QueryParam("filter") String filter,
-                            @QueryParam("limit") @DefaultValue("100")int limit, 
+                            @QueryParam("limit") @DefaultValue("100")int limit,
                             @QueryParam("offset") @DefaultValue("0") int offset) {
+        int cappedLimit = Math.min(Math.max(limit, 1), 1000);
+        int cappedOffset = Math.max(offset, 0);
         return storeManager.getJdbcChatMemoryStore()
             .map(store -> {
-                List<MemorySummary> listSummaries = store.listSummaries(filter, limit, offset);
+                List<MemorySummary> listSummaries = store.listSummaries(filter, cappedLimit, cappedOffset);
                 return Response.ok(listSummaries).build();
             })
             .orElseGet(() -> Response.noContent().build());
@@ -146,7 +149,8 @@ public class StoreEndpoint {
         try {
             String t = um.singleText();
             return t;
-        } catch (Throwable ignore) {
+        } catch (Throwable e) {
+            Log.debugf("Failed to extract singleText: %s", e.getMessage());
             return null;
         }
     }
@@ -154,10 +158,12 @@ public class StoreEndpoint {
     private static UserMessage userMessageFromText(String text) {
         try {
             return UserMessage.from(text);
-        } catch (Throwable ignore) {
+        } catch (Throwable e) {
+            Log.debugf("UserMessage.from(String) failed: %s", e.getMessage());
             try {
                 return UserMessage.userMessage(text);
-            } catch (Throwable ignore2) {
+            } catch (Throwable e2) {
+                Log.debugf("UserMessage.userMessage(String) failed: %s", e2.getMessage());
                 return UserMessage.from(List.of(new TextContent(text)));
             }
         }
@@ -166,7 +172,8 @@ public class StoreEndpoint {
     private static UserMessage userMessageFromContents(List<Content> contents) {
         try {
             return UserMessage.from(contents);
-        } catch (Throwable ignore) {
+        } catch (Throwable e) {
+            Log.debugf("UserMessage.from(List<Content>) failed: %s", e.getMessage());
             String joined = contents.stream()
                 .map(c -> c instanceof TextContent tc ? tc.text() : "")
                 .reduce("", (a, b) -> a.isEmpty() ? b : a + "\n" + b);

--- a/src/main/java/org/chappiebot/store/StoreManager.java
+++ b/src/main/java/org/chappiebot/store/StoreManager.java
@@ -25,7 +25,7 @@ public class StoreManager {
     @ConfigProperty(name = "chappie.rag.pgvector.dimension", defaultValue = "384")
     int dim;
     
-    private Optional<PgVectorEmbeddingStore> cached;
+    private volatile Optional<PgVectorEmbeddingStore> cached;
 
     private JdbcChatMemoryStore jdbcChatMemoryStore = null;
     
@@ -47,13 +47,17 @@ public class StoreManager {
     
     public Optional<JdbcChatMemoryStore> getJdbcChatMemoryStore(){
         if(this.jdbcChatMemoryStore == null){
-            resolveDataSource();
+            synchronized (this) {
+                if(this.jdbcChatMemoryStore == null){
+                    resolveDataSource();
+                }
+            }
         }
         if(this.jdbcChatMemoryStore == null){
             return Optional.empty();
         }
         return Optional.of(this.jdbcChatMemoryStore);
-    } 
+    }
     
     private DataSource resolveDataSource() {
         if (chappieDs != null && chappieDs.isResolvable()) {
@@ -87,7 +91,7 @@ public class StoreManager {
             st.execute(ddl);
             st.execute(idx);
         } catch (Exception e) {
-            Log.warn("No datasource available - Will use InMemoryChatMemoryStore");
+            Log.warn("No datasource available - chat memory disabled");
             return false;
         }
         return true;


### PR DESCRIPTION
 Transaction safety, input validation, concurrency

- Fix autocommit not restored in JdbcChatMemoryStore transactions (deleteConversation, updateMessages) — add rollback on error and restore in finally block
- Add volatile to StoreManager.cached for safe double-checked locking
- Synchronize getJdbcChatMemoryStore() to prevent concurrent resolveDataSource() calls
- Fix misleading log message "Will use InMemoryChatMemoryStore" (no such fallback exists)
- Add null/blank validation on queryMessage in SearchEndpoint (returns 400)
- Cap limit param in StoreEndpoint.getChats() to 1-1000
- Replace catch(Throwable ignore) with Log.debugf in StoreEndpoint message normalization
- Extract synonym map to static final constant in RetrievalProvider